### PR TITLE
PL-1300: new data format support & extra meta-annotation-columns 

### DIFF
--- a/skit_labels/commands.py
+++ b/skit_labels/commands.py
@@ -204,9 +204,9 @@ def processLabelstudioColumns(df_path: str):
     )
 
     df["labelstudio_raw_tag"] = df["tag"].apply(json.loads)
-    df["tag"] = df["labelstudio_raw_tag"].apply(annotations.extract_intent)
-    df["incorrect_transcript"] = df["labelstudio_raw_tag"].apply(annotations.extract_incorrect_transcript)
-    df["gold_ready_for_training"] = df["labelstudio_raw_tag"].apply(annotations.extract_gold_ready_for_training)
+    df["tag"] = df["labelstudio_raw_tag"].apply(annotations.extract_annotation_related_to_intents, args=(const.FROM_NAME_INTENT, const.FROM_NAME_INTENT))
+    df["incorrect_transcript"] = df["labelstudio_raw_tag"].apply(annotations.extract_annotation_related_to_intents, args=(const.FROM_NAME_GOLD_DATA, const.INCORRECT_TRANSCRIPT))
+    df["gold_ready_for_training"] = df["labelstudio_raw_tag"].apply(annotations.extract_annotation_related_to_intents, args=(const.FROM_NAME_GOLD_DATA, const.GOLD_READY_FOR_TRAINING))
     df.dropna(subset=["tag"], inplace=True)
     df.drop(columns=["labelstudio_raw_tag"], inplace=True)
     df.to_csv(df_path, index=False)

--- a/skit_labels/commands.py
+++ b/skit_labels/commands.py
@@ -198,12 +198,24 @@ def extract_intent_from_labelstudio_annotations(tag) -> Optional[str]:
 
     try:
 
-        tag = json.loads(tag)[0]["value"]
+        intent_tag = None
 
-        if "choices" in tag:
-            return tag["choices"][0]
-        elif "taxonomy" in tag:
-            return tag["taxonomy"][0][0]
+        tag = json.loads(tag)
+
+        # searching for the dictionary which has the intent, should have "from_name":"tag"
+        for subset_tag in tag:
+            if "from_name" in subset_tag and subset_tag["from_name"] == "tag":
+                intent_tag = subset_tag
+                break
+
+        if intent_tag is None: return None
+
+        intent_tag = intent_tag["value"]
+
+        if "choices" in intent_tag:
+            return intent_tag["choices"][0]
+        elif "taxonomy" in intent_tag:
+            return intent_tag["taxonomy"][0][0]
 
     except json.JSONDecodeError:
         logger.warning("please check tag column, it's unparseable to get a single value out")

--- a/skit_labels/constants.py
+++ b/skit_labels/constants.py
@@ -112,3 +112,12 @@ TOTAL = "total"
 TAGGED = "tagged"
 UNTAGGED = "untagged"
 VALID_DATA_LABELS = ["Client", "Ops", "UAT", "Live"]
+
+INCORRECT_TRANSCRIPT = "Incorrect Transcript"
+GOLD_READY_FOR_TRAINING = "[GOLD] READY FOR TRAINING"
+FROM_NAME = "from_name"
+FROM_NAME_GOLD_DATA = "gold-data"
+FROM_NAME_INTENT = "tag"
+CHOICES = "choices"
+TAXONOMY = "taxonomy"
+VALUE = "value"

--- a/skit_labels/labelstudio/annotations.py
+++ b/skit_labels/labelstudio/annotations.py
@@ -1,0 +1,78 @@
+
+from typing import Dict, Optional
+
+from loguru import logger
+
+from skit_labels import constants as const
+
+def extract_intent(tag: Dict) -> Optional[str]:
+
+    try:
+
+        intent_tag = None
+
+        # searching for the dictionary which has the intent, should have "from_name":"tag"
+        for subset_tag in tag:
+            if const.FROM_NAME in subset_tag and subset_tag[const.FROM_NAME] == const.FROM_NAME_INTENT:
+                intent_tag = subset_tag[const.VALUE]
+                break
+
+        if intent_tag is None: return None
+
+        if const.CHOICES in intent_tag:
+            return intent_tag[const.CHOICES][0]
+        elif const.TAXONOMY in intent_tag:
+            return intent_tag[const.TAXONOMY][0][0]
+
+    except Exception as e:
+        logger.warning("please check tag column, it's unparseable to get a single value out")
+
+    return None
+
+
+def extract_incorrect_transcript(tag: Dict) -> bool:
+
+    try:
+
+        incorrect_transcription_tag = None
+
+        # searching for the dictionary which has the incorrect-transcript, should have "from_name":"gold-data"
+        for subset_tag in tag:
+            if const.FROM_NAME in subset_tag \
+            and subset_tag[const.FROM_NAME] == const.FROM_NAME_GOLD_DATA:
+                incorrect_transcription_tag = subset_tag[const.VALUE]
+                break
+
+        if incorrect_transcription_tag is None: return False
+
+        if const.CHOICES in incorrect_transcription_tag:
+            return incorrect_transcription_tag[const.CHOICES][0] == const.INCORRECT_TRANSCRIPT
+
+    except Exception as e:
+        logger.warning(e)
+
+    return False
+
+
+def extract_gold_ready_for_training(tag: Dict) -> bool:
+
+    try:
+
+        ready_for_training_tag = None
+
+        # searching for the dictionary which has the ready-for-training, should have "from_name":"gold-data"
+        for subset_tag in tag:
+            if const.FROM_NAME in subset_tag \
+            and subset_tag[const.FROM_NAME] == const.FROM_NAME_GOLD_DATA:
+                ready_for_training_tag = subset_tag[const.VALUE]
+                break
+
+        if ready_for_training_tag is None: return False
+
+        if const.TAXONOMY in ready_for_training_tag:
+            return ready_for_training_tag[const.TAXONOMY][0][0] == const.GOLD_READY_FOR_TRAINING
+
+    except Exception as e:
+        logger.warning(e)
+
+    return False

--- a/skit_labels/labelstudio/annotations.py
+++ b/skit_labels/labelstudio/annotations.py
@@ -1,78 +1,51 @@
 
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from loguru import logger
 
 from skit_labels import constants as const
 
-def extract_intent(tag: Dict) -> Optional[str]:
+
+
+def extract_annotation_related_to_intents(
+        tag: Dict, 
+        annotation_from_name_value: str, 
+        annotation_search_parameter: str
+    ) -> Optional[Union[str, bool]]:
 
     try:
 
-        intent_tag = None
+        annotated_information = None
+        incorrect_transcript_and_gold_data_constants = [const.INCORRECT_TRANSCRIPT, const.GOLD_READY_FOR_TRAINING]
 
-        # searching for the dictionary which has the intent, should have "from_name":"tag"
+        # searching for the dictionary which has the sub-annotation, 
+        # should have matching "from_name": annotation_from_name_value
         for subset_tag in tag:
-            if const.FROM_NAME in subset_tag and subset_tag[const.FROM_NAME] == const.FROM_NAME_INTENT:
-                intent_tag = subset_tag[const.VALUE]
+            if const.FROM_NAME in subset_tag and subset_tag[const.FROM_NAME] in annotation_from_name_value:
+                annotated_information = subset_tag[const.VALUE]
                 break
 
-        if intent_tag is None: return None
+        if annotated_information is not None:
 
-        if const.CHOICES in intent_tag:
-            return intent_tag[const.CHOICES][0]
-        elif const.TAXONOMY in intent_tag:
-            return intent_tag[const.TAXONOMY][0][0]
+            if const.CHOICES in annotated_information:
+                choices_value = annotated_information[const.CHOICES][0]
 
-    except Exception as e:
-        logger.warning("please check tag column, it's unparseable to get a single value out")
+                # are we searching for intent or the other category (incorrect transcript & gold-ready-for-training)
+                # old way was getting tagged with choices
+                if annotation_search_parameter == const.FROM_NAME_INTENT:
+                    return choices_value
+                else:
+                    return choices_value.lower() == annotation_search_parameter.lower()
 
-    return None
-
-
-def extract_incorrect_transcript(tag: Dict) -> bool:
-
-    try:
-
-        incorrect_transcription_tag = None
-
-        # searching for the dictionary which has the incorrect-transcript, should have "from_name":"gold-data"
-        for subset_tag in tag:
-            if const.FROM_NAME in subset_tag \
-            and subset_tag[const.FROM_NAME] == const.FROM_NAME_GOLD_DATA:
-                incorrect_transcription_tag = subset_tag[const.VALUE]
-                break
-
-        if incorrect_transcription_tag is None: return False
-
-        if const.CHOICES in incorrect_transcription_tag:
-            return incorrect_transcription_tag[const.CHOICES][0] == const.INCORRECT_TRANSCRIPT
+            # new way of intent tagging is done with taxonomy
+            elif const.TAXONOMY in annotated_information:
+                return annotated_information[const.TAXONOMY][0][0]
 
     except Exception as e:
         logger.warning(e)
 
-    return False
+    if annotation_search_parameter in incorrect_transcript_and_gold_data_constants:
+        return False
+    else:
+        return None
 
-
-def extract_gold_ready_for_training(tag: Dict) -> bool:
-
-    try:
-
-        ready_for_training_tag = None
-
-        # searching for the dictionary which has the ready-for-training, should have "from_name":"gold-data"
-        for subset_tag in tag:
-            if const.FROM_NAME in subset_tag \
-            and subset_tag[const.FROM_NAME] == const.FROM_NAME_GOLD_DATA:
-                ready_for_training_tag = subset_tag[const.VALUE]
-                break
-
-        if ready_for_training_tag is None: return False
-
-        if const.TAXONOMY in ready_for_training_tag:
-            return ready_for_training_tag[const.TAXONOMY][0][0] == const.GOLD_READY_FOR_TRAINING
-
-    except Exception as e:
-        logger.warning(e)
-
-    return False

--- a/tests/test_annotation_parsing.py
+++ b/tests/test_annotation_parsing.py
@@ -1,4 +1,5 @@
 
+from skit_labels import constants as const
 from skit_labels.labelstudio import annotations
 
 
@@ -10,35 +11,51 @@ def test_extract_incorrect_transcript():
             {"id": "ri87XjuiK7", "type": "choices", "value": {"choices": ["Incorrect Transcript"]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
         ]
     
-    assert annotations.extract_incorrect_transcript(tag) == True
+    assert annotations.extract_annotation_related_to_intents(tag, const.FROM_NAME_GOLD_DATA, const.INCORRECT_TRANSCRIPT) == True
+    assert annotations.extract_annotation_related_to_intents(tag, const.FROM_NAME_GOLD_DATA, const.GOLD_READY_FOR_TRAINING) == False
 
 
 def test_extract_gold_ready_for_training():
 
-    tag = [
+    # [GOLD] READY FOR TRAINING
+    upper_case_tag = [
             {"id": "i1ItHBjQao", "type": "taxonomy", "value": {"taxonomy": [["_repeat_"]]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
-            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"taxonomy": [["[GOLD] READY FOR TRAINING"]]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
+            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"choices": ["[GOLD] READY FOR TRAINING"]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
         ]
     
-    assert annotations.extract_gold_ready_for_training(tag) == True
+    
+    assert annotations.extract_annotation_related_to_intents(upper_case_tag, const.FROM_NAME_GOLD_DATA, const.GOLD_READY_FOR_TRAINING) == True
+    assert annotations.extract_annotation_related_to_intents(upper_case_tag, const.FROM_NAME_GOLD_DATA, const.INCORRECT_TRANSCRIPT) == False
+
+    # [GOLD] Ready for Training
+    lower_case_tag = [{'id': 'SwhhaeW7Y3', 'type': 'choices', 'value': {'choices': ['[GOLD] Ready for Training']}, 'origin': 'manual', 'to_name': 'audio', 'from_name': 'gold-data'}, 
+           {'id': 'SzopXVMrLj', 'type': 'taxonomy', 'value': {'taxonomy': [['application_status']]}, 'origin': 'manual', 'to_name': 'audio', 'from_name': 'tag'}
+        ]
+    
+    assert annotations.extract_annotation_related_to_intents(lower_case_tag, const.FROM_NAME_GOLD_DATA, const.GOLD_READY_FOR_TRAINING) == True
+    assert annotations.extract_annotation_related_to_intents(lower_case_tag, const.FROM_NAME_GOLD_DATA, const.INCORRECT_TRANSCRIPT) == False
+
+
 
 
 def test_extract_intent_in_new_data_format():
 
     tag = [
             {"id": "i1ItHBjQao", "type": "taxonomy", "value": {"taxonomy": [["_repeat_"]]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
-            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"taxonomy": [["[GOLD] READY FOR TRAINING"]]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
+            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"choices": ["[GOLD] READY FOR TRAINING"]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
         ]
     
-    assert annotations.extract_intent(tag) == '_repeat_'
+    assert annotations.extract_annotation_related_to_intents(tag, const.FROM_NAME_INTENT, const.FROM_NAME_INTENT) == '_repeat_'
 
 
 def test_extract_intent_in_old_data_format():
 
     tag = [
-            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"taxonomy": [["[GOLD] READY FOR TRAINING"]]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"},
             {"id": "i1ItHBjQao", "type": "taxonomy", "value": {"choices": ["_repeat_"]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
+            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"choices": ["[GOLD] READY FOR TRAINING"]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"},
         ]
     
-    assert annotations.extract_intent(tag) == '_repeat_'
+    assert annotations.extract_annotation_related_to_intents(tag, const.FROM_NAME_INTENT, const.FROM_NAME_INTENT) == '_repeat_'
+
+
 

--- a/tests/test_annotation_parsing.py
+++ b/tests/test_annotation_parsing.py
@@ -1,0 +1,44 @@
+
+from skit_labels.labelstudio import annotations
+
+
+
+def test_extract_incorrect_transcript():
+
+    tag = [
+            {"id": "_FW0-mqUjQ", "type": "taxonomy", "value": {"taxonomy": [["_wheel_related_"]]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
+            {"id": "ri87XjuiK7", "type": "choices", "value": {"choices": ["Incorrect Transcript"]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
+        ]
+    
+    assert annotations.extract_incorrect_transcript(tag) == True
+
+
+def test_extract_gold_ready_for_training():
+
+    tag = [
+            {"id": "i1ItHBjQao", "type": "taxonomy", "value": {"taxonomy": [["_repeat_"]]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
+            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"taxonomy": [["[GOLD] READY FOR TRAINING"]]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
+        ]
+    
+    assert annotations.extract_gold_ready_for_training(tag) == True
+
+
+def test_extract_intent_in_new_data_format():
+
+    tag = [
+            {"id": "i1ItHBjQao", "type": "taxonomy", "value": {"taxonomy": [["_repeat_"]]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
+            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"taxonomy": [["[GOLD] READY FOR TRAINING"]]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"}
+        ]
+    
+    assert annotations.extract_intent(tag) == '_repeat_'
+
+
+def test_extract_intent_in_old_data_format():
+
+    tag = [
+            {"id": "UZDXRwSyMe", "type": "taxonomy", "value": {"taxonomy": [["[GOLD] READY FOR TRAINING"]]}, "origin": "manual", "to_name": "audio", "from_name": "gold-data"},
+            {"id": "i1ItHBjQao", "type": "taxonomy", "value": {"choices": ["_repeat_"]}, "origin": "manual", "to_name": "audio", "from_name": "tag"}, 
+        ]
+    
+    assert annotations.extract_intent(tag) == '_repeat_'
+


### PR DESCRIPTION
covers requests made by Chandra over [here](https://vernacular-ai.atlassian.net/browse/PL-1300).

namely,
1. support new labelstudio intent data format (previously `choices` , now `taxonomy` based)
2. create new boolean column for annotations (on turns) whether they are marked as "Incorrect Transcripts" or not.
3. create new boolean column for annotations (on turns) whether they are marked as "[GOLD] READY FOR TRAINING" or not.

have tested and confirmed that skit-labels works as expected for old-intent-data-format (job: 360) & new-intent-data-format (job: 525)

need to test incorrect-transcript & gold-ready-for-retraining on actual jobs which have tags related to them. till that will keep it in draft.